### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -75,7 +75,5 @@
   },
   "need_generate_pdf": false,
   "need_generate_intellisense": false,
-  "enable_branch_build_custom_validation": true,
-  "enable_pull_request_custom_validation": true,
   "template_folder": "_themes"
 }


### PR DESCRIPTION
disabling custom validation - build is erroneously pointing to pre-prod validation, which is resulting in build errors related to a new rule that's not in prod yet