### PR TITLE
Changed database name to database server in sample

### DIFF
--- a/Azure-RMSDocs/deploy-aip-scanner.md
+++ b/Azure-RMSDocs/deploy-aip-scanner.md
@@ -133,7 +133,7 @@ You can have one account to run the scanner service and use another account to a
 3. Run the [Install-AIPScanner](/powershell/module/azureinformationprotection/Install-AIPScanner) cmdlet, specifying your SQL Server instance on which to create a database for the Azure Information Protection scanner: 
     
     ```
-    Install-AIPScanner -SqlServerInstance <database name>
+    Install-AIPScanner -SqlServerInstance <database server>
     ```
     
     Examples:


### PR DESCRIPTION
The sample mentioned database name while the argument which you provide points to a database server. This was confusing as it gives you the idea you can provide an explicit name for the database that will be created hence the rename.