### PR TITLE
Improve code samples

### DIFF
--- a/Azure-RMSDocs/develop/authentication-integration.md
+++ b/Azure-RMSDocs/develop/authentication-integration.md
@@ -85,7 +85,7 @@ and comes from the previous registration step via the Azure portal.
 
 **Android user authentication** - for more information, see [Android code examples](android-code.md), **Step 2** of the first scenario, "Consuming an RMS protected file".
 
-
+```java
     class MsipcAuthenticationCallback implements AuthenticationRequestCallback
     {
     ...
@@ -97,8 +97,8 @@ and comes from the previous registration step via the Azure portal.
         String authority = authenticationParametersMap.get("oauth2.authority");
         String resource = authenticationParametersMap.get("oauth2.resource");
         String userId = authenticationParametersMap.get("userId");
-        mClientId = “12345678-ABCD-ABCD-ABCD-ABCDEFGHIJ”; // get your registered Azure AD application ID here
-        mRedirectUri = “urn:ietf:wg:oauth:2.0:oob”;
+        mClientId = "12345678-ABCD-ABCD-ABCD-ABCDEFGH12"; // get your registered Azure AD application ID here
+        mRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         final String userHint = (userId == null)? "" : userId;
         AuthenticationContext authenticationContext = App.getInstance().getAuthenticationContext();
         if (authenticationContext == null || !authenticationContext.getAuthority().equalsIgnoreCase(authority))
@@ -156,12 +156,12 @@ and comes from the previous registration step via the Azure portal.
                             }
                         });
                          }
-
+```
 
 **iOS/OS X user authentication** - for more information, see [iOS/OS X code examples](ios-os-x-code-examples.md),
 *Step 2 of the first scenario, "Consuming an RMS protected file".*
 
-
+```objectivec
     // AuthenticationCallback holds the necessary information to retrieve an access token.
     @interface MsipcAuthenticationCallback : NSObject<MSAuthenticationCallback>
 
@@ -177,11 +177,11 @@ and comes from the previous registration step via the Azure portal.
     ADAuthenticationError *error;
     ADAuthenticationContext* context = [ADAuthenticationContext authenticationContextWithAuthority:authenticationParameters.authority error:&error];
 
-    NSString *appClientId = @”12345678-ABCD-ABCD-ABCD-ABCDEFGHIJ”;
+    NSString *appClientId = @"12345678-ABCD-ABCD-ABCD-ABCDEFGH12";
 
     // get your registered Azure AD application ID here
 
-    NSURL *redirectURI = [NSURL URLWithString:@”ms-sample://com.microsoft.sampleapp”];
+    NSURL *redirectURI = [NSURL URLWithString:@"ms-sample://com.microsoft.sampleapp"];
 
     // get your <app-scheme>://<bundle-id> here
     // Retrieve token using ADAL
@@ -204,13 +204,12 @@ and comes from the previous registration step via the Azure portal.
 
         ];
     }
-
-
+```
 
 **Linux user authentication** - for more information, see [Linux code examples](linux-c-code-examples.md).
 
 
-
+```cpp
     // Class Header
     class AuthCallback : public IAuthenticationCallback {
     private:
@@ -270,3 +269,4 @@ and comes from the previous registration step via the Azure portal.
         throw;
       }
     }
+```

--- a/Azure-RMSDocs/develop/enabling-logging.md
+++ b/Azure-RMSDocs/develop/enabling-logging.md
@@ -54,49 +54,63 @@ In each of the example code snippets following, the calling application can set 
 ### Android ###
 Enable automatic logging
 
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    SharedPreferences.Editor editor = preferences.edit();
-    editor.putBoolean(&quot;IpcCustomerExperienceDataCollectionEnabled&quot;, true);
-    editor.commit();
+```java
+SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+SharedPreferences.Editor editor = preferences.edit();
+editor.putBoolean("IpcCustomerExperienceDataCollectionEnabled", true);
+editor.commit();
+```
 
 Get current logging control flag setting
 
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    Boolean isLogUploadEnabled = preferences.getBoolean(&quot;IpcCustomerExperienceDataCollectionEnabled&quot;, false);
+```java
+SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+Boolean isLogUploadEnabled = preferences.getBoolean(&quot;IpcCustomerExperienceDataCollectionEnabled&quot;, false);
+```
 
 ## iOS ##
 Enable automatic logging
 
-    NSUserDefaults \*prefs = [NSUserDefaults standardUserDefaults];
-        [prefs setBool:FALSE forKey:@&quot;IpcCustomerExperienceDataCollectionEnabled”];
-        [[NSUserDefaults standardUserDefaults] synchronize];
+```objectivec
+NSUserDefaults \*prefs = [NSUserDefaults standardUserDefaults];
+    [prefs setBool:FALSE forKey:@"IpcCustomerExperienceDataCollectionEnabled"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+```
 
 Get current logging control flag setting
 
-    [[NSUserDefaults standardUserDefaults] boolForKey:@&quot;IpcCustomerExperienceDataCollectionEnabled&quot;];
+```java
+[[NSUserDefaults standardUserDefaults] boolForKey:@"IpcCustomerExperienceDataCollectionEnabled"];
+```
 
 Set log level control
 
-    NSUserDefaults \*prefs = [NSUserDefaults standardUserDefaults];
-      [prefs setInteger:1 forKey:@&quot;IpcLogLevel”];
-      [[NSUserDefaults standardUserDefaults] synchronize];
+```java
+NSUserDefaults \*prefs = [NSUserDefaults standardUserDefaults];
+    [prefs setInteger:1 forKey:@"IpcLogLevel"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+```
 
 Get log level control setting
 
-    [[NSUserDefaults standardUserDefaults] boolForKey:@&quot;IpcLogLevel&quot;];
- 
+```java
+[[NSUserDefaults standardUserDefaults] boolForKey:@"IpcLogLevel"];
+```
 
 ## Windows ##
 Enable automatic logging
 
-    CustomerExperienceConfiguration::Option = CustomerExperienceOptions::LoggingEnabledNow;
+```cpp
+CustomerExperienceConfiguration::Option = CustomerExperienceOptions::LoggingEnabledNow;
+```
 
 For more information on optional settings, see [CustomerExperienceOptions](https://msdn.microsoft.com/library/microsoft.rightsmanagement.customerexperienceoptions.aspx).
 
 Get current logging control flag setting
 
-    CustomerExperienceOptions loggingOption = CustomerExperienceConfiguration::Option;
-
+```cpp
+CustomerExperienceOptions loggingOption = CustomerExperienceConfiguration::Option;
+```
 
 **Note** - The Windows code snips above are in C++. For C\#, update the syntax with ‘.’ in place of ‘::’.
 

--- a/Azure-RMSDocs/develop/file-api-configuration.md
+++ b/Azure-RMSDocs/develop/file-api-configuration.md
@@ -74,7 +74,7 @@ To specify the protection behavior, set the **Encryption** value in the key. If 
 
 
 > [!Note]
-> This setting has no bearing on Office file formats. For example, if the `HKEY_LOCAL_MACHINE\Software\Microsoft\MSIPC\FileProtection\DOCX\Encryption` value is set to &quot;Pfile”, .docx files will still be encrypted using native protection, and the encrypted file will still have a file extension of .docx.
+> This setting has no bearing on Office file formats. For example, if the `HKEY_LOCAL_MACHINE\Software\Microsoft\MSIPC\FileProtection\DOCX\Encryption` value is set to “Pfile”, .docx files will still be encrypted using native protection, and the encrypted file will still have a file extension of .docx.
 
 Setting any other value or setting no value results in default behavior.
 

--- a/Azure-RMSDocs/develop/how-to-enable-email-notification.md
+++ b/Azure-RMSDocs/develop/how-to-enable-email-notification.md
@@ -30,22 +30,23 @@ Email notification allows for a protected content owner to be notified when his 
 
 To setup your email notification for a given license, use [IpcSetLicenseProperty](https://msdn.microsoft.com/library/hh535271.aspx) with the property type parameter, *dwPropID*, as [IPC\_LI\_APP\_SPECIFIC\_DATA](https://msdn.microsoft.com/library/hh535287.aspx) and the application data fields formatted as an [IPC\_NAME\_VALUE\_LIST](https://msdn.microsoft.com/library/hh535277.aspx).
 
-    C++
+**C++**:
 
-    int numDataPairs = 3;
+```cpp
+int numDataPairs = 3;
 
-    IPC_NAME_VALUE propertyValuePairs [numDataPairs];
+IPC_NAME_VALUE propertyValuePairs [numDataPairs];
 
-    // lcid field set to 0 causes the default lcid to be used
+// lcid field set to 0 causes the default lcid to be used
 
-    propertyValuePairs[0] = {"MS.Conetent.Name", 0, "FinancialReport.docx"};
-    propertyValuePairs[1] = {"MS.Notify.Enabled",0 , "true"};
-    propertyValuePairs[2] = {"MS.Notify.Culture",0 , “en-US”};
+propertyValuePairs[0] = {"MS.Conetent.Name", 0, "FinancialReport.docx"};
+propertyValuePairs[1] = {"MS.Notify.Enabled",0 , "true"};
+propertyValuePairs[2] = {"MS.Notify.Culture",0 , "en-US"};
 
-    IPC_NAME_VALUE_LIST emailNotificationAppData = {numDataPairs, propertyValuePairs};
+IPC_NAME_VALUE_LIST emailNotificationAppData = {numDataPairs, propertyValuePairs};
 
-    result = IpcSetLicenseProperty( licenseHandle, FALSE, IPC_LI_APP_SPECIFIC_DATA, emailNotificationAppData);
-
+result = IpcSetLicenseProperty(licenseHandle, FALSE, IPC_LI_APP_SPECIFIC_DATA, emailNotificationAppData);
+```
 
 The following table contains the application data fields, property name and value pairs, for RMS email notification.
 

--- a/Azure-RMSDocs/develop/ios-os-x-code-examples.md
+++ b/Azure-RMSDocs/develop/ios-os-x-code-examples.md
@@ -44,6 +44,7 @@ Following are **Objective C** code examples from a larger sample application rep
 
   **Description**: Instantiate an [MSProtectedData](https://msdn.microsoft.com/library/dn758348.aspx) object, through its create method which implements service authentication using the [MSAuthenticationCallback](https://msdn.microsoft.com/library/dn758312.aspx) to get a token by passing an instance of **MSAuthenticationCallback**, as the parameter *authenticationCallback*, to the MSIPC API. See the call to [MSProtectedData protectedDataWithProtectedFile](https://msdn.microsoft.com/library/dn758351.aspx) in the following example code section.
 
+    ```objectivec
         + (void)consumePtxtFile:(NSString *)path authenticationCallback:(id<MSAuthenticationCallback>)authenticationCallback
         {
             // userId can be provided as a hint for authentication
@@ -57,11 +58,13 @@ Following are **Objective C** code examples from a larger sample application rep
                 NSData *content = [data retrieveData];
             }];
         }
+    ```
 
 - **Step 2**: Setup authentication using the Active Directory Authentication Library (ADAL).
 
   **Description**: In this step you will see ADAL used to implement an [MSAuthenticationCallback](https://msdn.microsoft.com/library/dn758312.aspx) with example authentication parameters. For more information on using ADAL, see the Azure AD Authentication Library (ADAL).
 
+    ```objectivec
       // AuthenticationCallback holds the necessary information to retrieve an access token.
       @interface MsipcAuthenticationCallback : NSObject<MSAuthenticationCallback>
 
@@ -79,7 +82,7 @@ Following are **Objective C** code examples from a larger sample application rep
               ADAuthenticationContext authenticationContextWithAuthority:authenticationParameters.authority
                                                                 error:&error
           ];
-          NSString *appClientId = @”com.microsoft.sampleapp”;
+          NSString *appClientId = @"com.microsoft.sampleapp";
           NSURL *redirectURI = [NSURL URLWithString:@"local://authorize"];
           // Retrieve token using ADAL
           [context acquireTokenWithResource:authenticationParameters.resource
@@ -98,9 +101,11 @@ Following are **Objective C** code examples from a larger sample application rep
                               }
                           }];
        }
+    ```
 
 - **Step 3**: Check if the Edit right exists for this user with this content via the [MSUserPolicy accessCheck](https://msdn.microsoft.com/library/dn790789.aspx) method of a [MSUserPolicy](https://msdn.microsoft.com/library/dn790796.aspx) object.
 
+    ```objectivec
       - (void)accessCheckWithProtectedData:(MSProtectedData *)protectedData
       {
           //check if user has edit rights and apply enforcements
@@ -112,6 +117,7 @@ Following are **Objective C** code examples from a larger sample application rep
               textEditor.enabled = NO;
           }
       }
+    ```
 
 ### Scenario: Create a new protected file using a template
 
@@ -119,6 +125,7 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
 
 -   **Step 1**: Get list of templates
 
+    ```objectivec
         + (void)templateListUsageWithAuthenticationCallback:(id<MSAuthenticationCallback>)authenticationCallback
         {
             [MSTemplateDescriptor templateListWithUserId:@"user@domain.com"
@@ -128,9 +135,11 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
                                      // use templates array of MSTemplateDescriptor (Note: will be nil on error)
                                    }];
         }
+    ```
 
 -   **Step 2**: Create a [MSUserPolicy](https://msdn.microsoft.com/library/dn790796.aspx) using the first template in the list.
 
+    ```objectivec
         + (void)userPolicyCreationFromTemplateWithAuthenticationCallback:(id<MSAuthenticationCallback>)authenticationCallback
         {
             [MSUserPolicy userPolicyWithTemplateDescriptor:[templates objectAtIndex:0]
@@ -143,9 +152,11 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
             // use userPolicy (Note: will be nil on error)
             }];
         }
+    ```
 
 -   **Step 3**: Create a [MSMutableProtectedData](https://msdn.microsoft.com/library/dn758325.aspx) and write content to it.
 
+    ```objectivec
         + (void)createPtxtWithUserPolicy:(MSUserPolicy *)userPolicy contentToProtect:(NSData *)contentToProtect
         {
             // create an MSMutableProtectedData to write content
@@ -157,12 +168,14 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
              // use data (Note: will be nil on error)
             }];
         }
+    ```
 
 ### Scenario: Open a custom protected file
 
 
 -   **Step 1**: Create a [MSUserPolicy](https://msdn.microsoft.com/library/dn790796.aspx) from a *serializedContentPolicy*.
 
+    ```objectivec
         + (void)userPolicyWith:(NSData *)protectedData
         authenticationCallback:(id<MSAuthenticationCallback>)authenticationCallback
         {
@@ -188,9 +201,11 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
 
             }];
          }
+    ```
 
 -   **Step 2**: Create a [MSCustomProtectedData](https://msdn.microsoft.com/library/dn758321.aspx) using the [MSUserPolicy](https://msdn.microsoft.com/library/dn790796.aspx) from **Step 1** and read from it.
 
+    ```objectivec
         + (void)customProtectedDataWith:(NSData *)protectedData
         {
             // Read header information from protectedData and extract the  protectedContentSize
@@ -215,6 +230,7 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
              NSLog(@"%@", content);
             }];
          }
+    ```
 
 ### Scenario: Create a custom protected file using a custom (ad-hoc) policy
 
@@ -223,6 +239,7 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
 
     **Description**: In practice the following objects would be created by using user inputs from the device interface; [MSUserRights](https://msdn.microsoft.com/library/dn790811.aspx) and [MSPolicyDescriptor](https://msdn.microsoft.com/library/dn758339.aspx).
 
+    ```objectivec
         + (void)policyDescriptor
         {
             MSUserRights *userRights = [[MSUserRights alloc] initWithUsers:[NSArray arrayWithObjects: @"user1@domain.com", @"user2@domain.com", nil] rights:[MSEmailRights all]];
@@ -231,9 +248,11 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
             policyDescriptor.contentValidUntil = [[NSDate alloc] initWithTimeIntervalSinceNow:NSTimeIntervalSince1970 + 3600.0];
             policyDescriptor.offlineCacheLifetimeInDays = 10;
         }
+    ```
 
 -   **Step 2**: Create a custom [MSUserPolicy](https://msdn.microsoft.com/library/dn790796.aspx) from the policy descriptor, *selectedDescriptor*.
 
+    ```objectivec
         + (void)userPolicyWithPolicyDescriptor:(MSPolicyDescriptor *)policyDescriptor
         {
             [MSUserPolicy userPolicyWithPolicyDescriptor:policyDescriptor
@@ -245,9 +264,11 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
               // use userPolicy (Note: will be nil on error)
             }];
         }
+    ```
 
 -   **Step 3**: Create and write content to the [MSMutableCustomProtectedData](https://msdn.microsoft.com/library/dn758321.aspx) and then close.
 
+    ```objectivec
         + (void)mutableCustomProtectedData:(NSMutableData *)backingData policy:(MSUserPolicy *)policy contentToProtect:(NSString *)contentToProtect
         {
             //Get the serializedPolicy from a given policy
@@ -282,3 +303,4 @@ This scenario begins with getting a list of templates, [MSTemplateDescriptor](ht
 
             }];
           }
+    ```

--- a/Azure-RMSDocs/develop/linux-c-code-examples.md
+++ b/Azure-RMSDocs/develop/linux-c-code-examples.md
@@ -39,6 +39,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     void MainWindow::ConvertFromPFILE(const string& fileIn,
         const string& clientId,
         const string& redirectUrl,
@@ -99,6 +100,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     inFile->close();
     outFile->close();
     }
+  ```
 
 **Create a protected file stream**
 **Source**: [rms\_sample/pfileconverter.cpp](https://github.com/AzureAD/rms-sdk-for-cpp/tree/master/samples/rms_sample)
@@ -107,6 +109,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     shared_ptr<GetProtectedFileStreamResult>PFileConverter::ConvertFromPFile(
     const string           & userId,
     shared_ptr<istream>      inStream,
@@ -149,6 +152,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     }
       return fsResult;
     }
+  ```
 
 ## Scenario: Create a new protected file using a template
 
@@ -159,6 +163,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     void MainWindow::ConvertToPFILEUsingTemplates(const string& fileIn,
                                               const string& clientId,
                                               const string& redirectUrl,
@@ -219,6 +224,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     inFile->close();
     outFile->close();
     }
+  ```
 
 
 **Protects a file using a policy created from a template**
@@ -228,6 +234,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     void PFileConverter::ConvertToPFileTemplates(const string           & userId,
                                              shared_ptr<istream>      inStream,
                                              const string           & fileExt,
@@ -253,6 +260,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     ConvertToPFileUsingPolicy(policy, inStream, fileExt, outStream);
     }
     }
+  ```
 
 **Protects a file given a policy**
 **Source**: [rms\_sample/pfileconverter.cpp](https://github.com/AzureAD/rms-sdk-for-cpp/tree/master/samples/rms_sample)
@@ -261,6 +269,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     void PFileConverter::ConvertToPFileUsingPolicy(shared_ptr<UserPolicy>   policy,
                                                shared_ptr<istream>      inStream,
                                                const string           & fileExt,
@@ -293,7 +302,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     
     pStream->Flush();
     }
-    
+  ```
 
 
 ## Scenario: Protect a file using custom protection
@@ -305,6 +314,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     void MainWindow::ConvertToPFILEUsingRights(const string            & fileIn,
                                            const vector<UserRights>& userRights,
                                            const string            & clientId,
@@ -379,6 +389,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     inFile->close();
     outFile->close();
     }
+  ```
 
 
 **Creates a protection policy give user selected rights**
@@ -388,6 +399,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
 
 **C++**:
 
+  ```cpp
     void PFileConverter::ConvertToPFilePredefinedRights(
     const string            & userId,
     shared_ptr<istream>       inStream,
@@ -411,6 +423,7 @@ The code snippets below are from the sample applications, *rms\_sample* and *rms
     auto policy = UserPolicy::Create(desc, userId, auth,
                                    USER_AllowAuditedExtraction);
     ConvertToPFileUsingPolicy(policy, inStream, fileExt, outStream);
+  ```
     
 
 ## WorkerThread - a supporting method
@@ -420,15 +433,18 @@ The *WorkerThread()* method is called by two of the previous example scenarios; 
 
 **C++**:
 
+  ```cpp
     threadPool.push_back(thread(WorkerThread,
                                   static_pointer_cast<iostream>(outStream), pfs,
                                   false));
+  ```
 
 
 **Supporting method, WorkerThread()**
 
 **C++**:
 
+  ```cpp
     static mutex   threadLocker;
     static int64_t totalSize     = 0;
     static int64_t readPosition  = 0;
@@ -506,6 +522,7 @@ The *WorkerThread()* method is called by two of the previous example scenarios; 
     }
     }
     }
+  ```
 
 
 ## Scenario: RMS authentication
@@ -519,7 +536,9 @@ Description: You can set cache path or use default.
 
 **C++**:
 
+  ```cpp
     auto FileCachePtr = std::make_shared< rmsauth::FileCache>();
+  ```
 
 
 **Step 2**: Create **rmsauth::AuthenticationContext** object
@@ -527,10 +546,12 @@ Description: Specify Azure *authority URI* and *FileCache* object.
 
 **C++**:
 
+  ```cpp
     AuthenticationContext authContext(
-                              std::string(“https://sts.aadrm.com/_sts/oauth/authorize”),
+                              std::string("https://sts.aadrm.com/_sts/oauth/authorize"),
                               AuthorityValidationType::False,
                               FileCachePtr);
+  ```
 
 
 **Step 3**: Call **aquireToken** method of **authContext** object and specify next parameters:
@@ -544,13 +565,14 @@ Description:
 
 **C++**:
 
+  ```cpp
     auto result = authContext.acquireToken(
-                std::string(“api.aadrm.com”),
-                std::string(“4a63455a-cfa1-4ac6-bd2e-0d046cf1c3f7”),
-                std::string(“https://client.test.app”),
+                std::string("api.aadrm.com"),
+                std::string("4a63455a-cfa1-4ac6-bd2e-0d046cf1c3f7"),
+                std::string("https://client.test.app"),
                 PromptBehavior::Auto,
-                std::string(“john.smith@msopentechtest01.onmicrosoft.com”));
-
+                std::string("john.smith@msopentechtest01.onmicrosoft.com"));
+  ```
 
 **Step 4**: Get access token from result
 Description: Call **result-> accessToken()** method
@@ -566,7 +588,9 @@ Description: You can set cache path or use default
 
 **C++**:
 
+  ```cpp
     auto FileCachePtr = std::make_shared< rmsauth::FileCache>();
+  ```
 
 
 **Step 2**:Create **UserCredential** object
@@ -574,19 +598,22 @@ Description: Specify *user login* and *password*
 
 **C++**:
 
+  ```cpp
     auto userCred = std::make_shared<UserCredential>("john.smith@msopentechtest01.onmicrosoft.com",
                                                  "SomePass");
-
+  ```
 
 **Step 3**:Create **rmsauth::AuthenticationContext** object
 Description: Specify Azure authority *URI* and *FileCache* object
 
 **C++**:
 
+  ```cpp
     AuthenticationContext authContext(
-                        std::string(“https://sts.aadrm.com/_sts/oauth/authorize”),
+                        std::string("https://sts.aadrm.com/_sts/oauth/authorize"),
                         AuthorityValidationType::False,
                         FileCachePtr);
+  ```
 
 
 **Step 4**: Call the **aquireToken** method of **authContext** and specify parameters:
@@ -596,10 +623,12 @@ Description: Specify Azure authority *URI* and *FileCache* object
 
 **C++**:
 
+  ```cpp
     auto result = authContext.acquireToken(
-                std::string(“api.aadrm.com”),
-                std::string(“4a63455a-cfa1-4ac6-bd2e-0d046cf1c3f7”),
+                std::string("api.aadrm.com"),
+                std::string("4a63455a-cfa1-4ac6-bd2e-0d046cf1c3f7"),
                 userCred);
+  ```
 
 
 **Step 5**: Get access token from result

--- a/Azure-RMSDocs/develop/tracking-content.md
+++ b/Azure-RMSDocs/develop/tracking-content.md
@@ -98,7 +98,9 @@ Lastly, use this API to register your tracked document with the tracking system.
 
 Here's a code snippet showing an example of setting document tracking metadata and the call to register with the tracking system.
 
-      C++
+**C++**:
+
+  ```cpp
       HRESULT hr = S_OK;
       LPCWSTR wszOutputFile = NULL;
       wstring wszWorkingFile;
@@ -128,7 +130,7 @@ Here's a code snippet showing an example of setting document tracking metadata a
      /* the context to use for the call */
      PCIPC_PROMPT_CTX pContext;
 
-     wstring wstrContentName(“MyDocument.txt”);
+     wstring wstrContentName("MyDocument.txt");
      bool sendLicenseRegistrationNotificationEmail = FALSE;
 
      hr = IpcRegisterLicense( pSerializedLicense,
@@ -136,6 +138,7 @@ Here's a code snippet showing an example of setting document tracking metadata a
                         pContext,
                         wstrContentName.c_str(),
                         sendLicenseRegistrationNotificationEmail);
+  ```
 
 ## Add a **Track Usage** button to your app
 


### PR DESCRIPTION
- Wrap code blocks with language specific tags so code highlighting can work
- Fix smart quotes in code samples
- Aligned some "C++" titles present over code samples
- Don't use I & J in GUID examples, those are not valid Hex chars