### PR TITLE
Update the solution in the FAQ to one that's compatible with Unified …

### DIFF
--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -95,9 +95,10 @@ To add this field code in your document:
 4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
 
 <pre>
-```{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }```
+  {IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }
 </pre>
-(replace the text at the end with what you want to display when the current label is applied to the document)
+
+&nbsp;&nbsp;&nbsp;(replace the text at the end with what you want to display when the current label is applied to the document)
 
 
 5.	Format the text as desired and press **Shift-F9** again to display the resulting text as part of the custom content marking. If the label doesn’t match the GUID specified the text won’t be displayed. You can concatenate the string above using different GUIDs and text to accommodate multiple labels. 

--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -89,13 +89,15 @@ To add this field code in your document:
 
 1. Label the document and save it. This action creates new metadata fields that you can now use for your field code.
 
-2. In the document, position the cursor where you want to add the label's classification and then, from the **Insert** tab, select **Text** > **Quick Parts** > **Field**.
+1.	In the document, create a header, footer or watermark (e.g. using WordArt or a text box) and position the cursor where you want to add the label's classification inserted and then, from the **Insert** tab, select **Quick Parts** under the **Text** secrion > **Field**.
+2.	In the **Field** dialog box, from the **Categories** dropdown, select **Document Information**. Then, from the **Field** names dropdown, select **DocProperty**.
+3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full nake of the property you have selected to confirm it's the right one), and select **OK**.
+4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
+`{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }`
+(replace the text at the end with what you want to display when the current label is applied to the document)
+5.	Format the text as desired and press **Shift-F9** again to display the resulting text as part of the custom content marking. If the label doesn’t match the GUID specified the text won’t be displayed. You can concatenate the string above using different GUIDs and text to accommodate multiple labels. 
 
-3. In the **Field** dialog box, from the **Categories** dropdown, select **Document Information**. Then, from the **Fields names** dropdown, select **DocProperty**.
-
-4. From the **Property** dropdown, select **Sensitivity**, and select **OK**.
-
-The current label's classification is displayed in the document and this value will be refreshed automatically whenever you open the document or use the template. So if the label changes, the classification that is displayed for this field code is automatically updated in the document.
+This method will display the text you defined if the label corresponding to the GUID you entered is applied to the document and this value will be refreshed automatically whenever you open the document or use the template. If the label changes, the text that is displayed for this field code is automatically updated in the document.
 
 ## How is classification for emails using Azure Information Protection different from Exchange message classification?
 

--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -91,7 +91,7 @@ To add this field code in your document:
 
 1.	In the document, create a header, footer or watermark (e.g. using WordArt or a text box) and position the cursor where you want to add the label's classification inserted and then, from the **Insert** tab, select **Quick Parts** under the **Text** section > **Field**.
 2.	In the **Field** dialog box, from the **Categories** dropdown, select **Document Information**. Then, from the **Field names** dropdown, select **DocProperty**.
-3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full nake of the property you have selected to confirm it's the right one), and select **OK**.
+3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full name of the property you have selected to confirm it's the right one), and select **OK**.
 4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
 `{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }`
 (replace the text at the end with what you want to display when the current label is applied to the document)

--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -93,7 +93,9 @@ To add this field code in your document:
 2.	In the **Field** dialog box, from the **Categories** dropdown, select **Document Information**. Then, from the **Field names** dropdown, select **DocProperty**.
 3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full name of the property you have selected to confirm it's the right one), and select **OK**.
 4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
+
 `{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }`
+
 (replace the text at the end with what you want to display when the current label is applied to the document)
 5.	Format the text as desired and press **Shift-F9** again to display the resulting text as part of the custom content marking. If the label doesn’t match the GUID specified the text won’t be displayed. You can concatenate the string above using different GUIDs and text to accommodate multiple labels. 
 

--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -94,8 +94,9 @@ To add this field code in your document:
 3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full name of the property you have selected to confirm it's the right one), and select **OK**.
 4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
 
+<pre>
 ```{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }```
-
+</pre>
 (replace the text at the end with what you want to display when the current label is applied to the document)
 
 

--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -89,8 +89,8 @@ To add this field code in your document:
 
 1. Label the document and save it. This action creates new metadata fields that you can now use for your field code.
 
-1.	In the document, create a header, footer or watermark (e.g. using WordArt or a text box) and position the cursor where you want to add the label's classification inserted and then, from the **Insert** tab, select **Quick Parts** under the **Text** secrion > **Field**.
-2.	In the **Field** dialog box, from the **Categories** dropdown, select **Document Information**. Then, from the **Field** names dropdown, select **DocProperty**.
+1.	In the document, create a header, footer or watermark (e.g. using WordArt or a text box) and position the cursor where you want to add the label's classification inserted and then, from the **Insert** tab, select **Quick Parts** under the **Text** section > **Field**.
+2.	In the **Field** dialog box, from the **Categories** dropdown, select **Document Information**. Then, from the **Field names** dropdown, select **DocProperty**.
 3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full nake of the property you have selected to confirm it's the right one), and select **OK**.
 4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
 `{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }`

--- a/Azure-RMSDocs/faqs-infoprotect.md
+++ b/Azure-RMSDocs/faqs-infoprotect.md
@@ -94,9 +94,11 @@ To add this field code in your document:
 3.	From the **Property** dropdown, select the property named **MSIP_Label_{*label GUID*}_Enabled** (the label GUID is the identifier of the label applied to the current document, you might need to select the option **Feld Codes** in order to show the full name of the property you have selected to confirm it's the right one), and select **OK**.
 4.	Press **Shift-F9** to show field codes, and then edit the field code in the greyed area as follows:
 
-`{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }`
+```{IF {DOCPROPERTY  MSIP_Label_{label GUID}_Enabled } = true “The sensitivity is Labelname” }```
 
 (replace the text at the end with what you want to display when the current label is applied to the document)
+
+
 5.	Format the text as desired and press **Shift-F9** again to display the resulting text as part of the custom content marking. If the label doesn’t match the GUID specified the text won’t be displayed. You can concatenate the string above using different GUIDs and text to accommodate multiple labels. 
 
 This method will display the text you defined if the label corresponding to the GUID you entered is applied to the document and this value will be refreshed automatically whenever you open the document or use the template. If the label changes, the text that is displayed for this field code is automatically updated in the document.


### PR DESCRIPTION
…Labeling and built-in sensitivity labels

The original solution proposed in the FAQ to support document templates no longer works in the Unified Labeling or the built-in sensitivity labels since the document property used is no longer present. The updated process is more complex but works in all clients.