### PR TITLE
Incorrect key name (Set-labelpolicy is not the key name, it's the com…

### DIFF
--- a/Azure-RMSDocs/rms-client/clientv2-admin-guide-customizations.md
+++ b/Azure-RMSDocs/rms-client/clientv2-admin-guide-customizations.md
@@ -230,7 +230,7 @@ This configuration uses a policy [advanced setting](#how-to-configure-advanced-s
 
 When you configure this setting, the  [PowerShell](https://docs.microsoft.com/azure/information-protection/rms-client/clientv2-admin-guide-powershell) cmdlet **Set-AIPFileLabel** is enabled to allow removal of protection from PST, rar, 7zip and MSG files.
 
-- Key: **Set-LabelPolicy**
+- Key: **EnableContainerSupport**
 
 - Value: **True**
 


### PR DESCRIPTION
…mand used to set it)

The Key name listed for EnableContainerSupport was Set-Labelpolicy. That's the name of the commandlet (and its the same as for all other advanced settings). The right key name is EnableContainerSupport.