### PR TITLE
Sensitivity labels in OWA are GA, Message Classification section needs to only cover Exchange Server

### DIFF
--- a/Azure-RMSDocs/rms-client/client-admin-guide-customizations.md
+++ b/Azure-RMSDocs/rms-client/client-admin-guide-customizations.md
@@ -983,7 +983,7 @@ This advanced client setting does not change the information that's sent to Azur
 
 Outlook on the web now supports built-in labeling for Exchange Online, which is the recommended method to label emails in Outlook on the web. However, if you need to label emails in OWA and are using Exchange Server, which doesn't yet support sensitivity labels, you can use Exchange message classification to extend Azure Information Protection labels to Outlook on the web.
 
-Please note that Outlook Mobile does not support Exchange message classification.
+Outlook Mobile does not support Exchange message classification.
 
 To achieve this solution: 
 

--- a/Azure-RMSDocs/rms-client/client-admin-guide-customizations.md
+++ b/Azure-RMSDocs/rms-client/client-admin-guide-customizations.md
@@ -979,11 +979,11 @@ Set the logging level to one of the following values:
 
 This advanced client setting does not change the information that's sent to Azure Information Protection for [central reporting](../reports-aip.md), or change the information that's written to the local [event log](client-admin-guide-files-and-logging.md#usage-logging-for-the-azure-information-protection-client).
 
-## Integration with Exchange message classification for a mobile device labeling solution
+## Integration with the legacy Exchange message classification
 
-Outlook on the web now supports built-in labeling for Exchange Online, which is the recommended method to label emails in Outlook on the web. However, if you're not yet using sensitivity labels that are published from the Office 365 Security & Compliance Center, Microsoft 365 security center, or Microsoft compliance center, you can use Exchange message classification to extend Azure Information Protection labels to your mobile users when they use Outlook on the web. You can also use this method for Exchange Server. 
+Outlook on the web now supports built-in labeling for Exchange Online, which is the recommended method to label emails in Outlook on the web. However, if you need to label emails in OWA and are using Exchange Server, which doesn't yet support sensitivity labels, you can use Exchange message classification to extend Azure Information Protection labels to Outlook on the web.
 
-Outlook Mobile does not support Exchange message classification.
+Please note that Outlook Mobile does not support Exchange message classification.
 
 To achieve this solution: 
 


### PR DESCRIPTION
…ange Server

Eliminated all references to using this solution for OWA in Office 365, since it is only useful for backwards compatibility with Exchange server.