### PR TITLE
Fixed an error in the PowerShell example

### DIFF
--- a/Azure-RMSDocs/rms-client/clientv2-admin-guide-customizations.md
+++ b/Azure-RMSDocs/rms-client/clientv2-admin-guide-customizations.md
@@ -1015,7 +1015,10 @@ To modify this timeout, create the following advanced setting for the selected p
 Example PowerShell command, where your label policy is named "Global":
 
 ```PowerShell
-Set-LabelPolicy -Identity Global -AdvancedSettings @{EnableOutlookDistributionListExpansion="true"} @{OutlookGetEmailAddressesTimeOutMSProperty="3000"}
+Set-LabelPolicy -Identity Global -AdvancedSettings @{
+  EnableOutlookDistributionListExpansion="true"
+  OutlookGetEmailAddressesTimeOutMSProperty="3000"
+}
 ```
 
 ## Disable sending audit data to Azure Information Protection analytics


### PR DESCRIPTION
You cannot pass to hash tables that way. It needs to be one.

I don't know why GitHub thinks that I also changed line 2079. Some line break issue, I believe.