### PR TITLE
Include Exchange 2019 among the supported versions

### DIFF
--- a/Azure-RMSDocs/requirements.md
+++ b/Azure-RMSDocs/requirements.md
@@ -264,7 +264,7 @@ Supported servers include:
 
 |Server type  |Supported versions  |
 |---------|---------|
-|**Exchange Server**     | - Exchange Server 2016 </br>- Exchange Server 2013 </br>- Exchange Server 2010       |
+|**Exchange Server**     | Exchange Server 2019 </br> - Exchange Server 2016 </br>- Exchange Server 2013 </br>- Exchange Server 2010       |
 |**Office SharePoint Server**     |- Office SharePoint Server 2016 </br>- Office SharePoint Server 2013 </br>- Office SharePoint Server 2010         |
 |**File servers that run Windows Server and use File Classification Infrastructure (FCI)**     |- Windows Server 2016 </br>- Windows Server 2012 R2 </br>- Windows Server 2012       |
 | | |

--- a/Azure-RMSDocs/requirements.md
+++ b/Azure-RMSDocs/requirements.md
@@ -264,7 +264,7 @@ Supported servers include:
 
 |Server type  |Supported versions  |
 |---------|---------|
-|**Exchange Server**     | Exchange Server 2019 </br> - Exchange Server 2016 </br>- Exchange Server 2013 </br>- Exchange Server 2010       |
+|**Exchange Server**     | - Exchange Server 2019 </br> - Exchange Server 2016 </br>- Exchange Server 2013 </br>- Exchange Server 2010       |
 |**Office SharePoint Server**     |- Office SharePoint Server 2016 </br>- Office SharePoint Server 2013 </br>- Office SharePoint Server 2010         |
 |**File servers that run Windows Server and use File Classification Infrastructure (FCI)**     |- Windows Server 2016 </br>- Windows Server 2012 R2 </br>- Windows Server 2012       |
 | | |


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/information-protection/configure-servers-rms-connector#configuring-an-exchange-server-to-use-the-connector already has references about the 2019 Exchange version.