### PR TITLE
Forcing a line break required for understanding

### DIFF
--- a/Azure-RMSDocs/rms-client/client-admin-guide-customizations.md
+++ b/Azure-RMSDocs/rms-client/client-admin-guide-customizations.md
@@ -805,9 +805,10 @@ Because some documents might include invisible characters or different kinds of 
 
 If a header or footer text is more than a single line, create a key and value for each line. For example, you have the following footer with two lines:
 
-**The file is classified as Confidential**
-
-**Label applied manually**
+```
+The file is classified as Confidential
+Label applied manually
+```
 
 To remove this multiline footer, you create the following two entries:
 


### PR DESCRIPTION
The line break in this multi-line label did show in the GitHub preview correctly already. But it's not there on https://docs.microsoft.com/en-us/azure/information-protection/rms-client/clientv2-admin-guide-customizations#multiline-headers-or-footers

Marking this as code should make it show correctly on docs.microsoft.com