### PR TITLE
Update configure-servers-rms-connector.md

### DIFF
--- a/Azure-RMSDocs/configure-servers-rms-connector.md
+++ b/Azure-RMSDocs/configure-servers-rms-connector.md
@@ -44,8 +44,8 @@ This means configuring the following servers:
 
 |Environment  |Servers to configure  |
 |---------|---------|
-|**Exchange 2016 and Exchange 2013**     |  Client access servers and mailbox servers       |
-|**Exchange 2019**     |   Client access servers and hub transport servers      |
+|**Exchange 2013**     |  Client Access Servers and Mailbox Servers       |
+|**Exchange 2016 and Exchange 2019**     |   Mailbox Servers (includes Client Access and Hub Transport server roles  )   |
 |**SharePoint**     |    Front-end SharePoint webservers, including those hosting the Central Administration server     |
 |**File Classification Infrastructure**     |   Windows Server computers that have installed File Resource Manager      |
 | | |


### PR DESCRIPTION
Made correction to Exchange Server versions, 2016 & 2019 are similar and needs this connector on CAS and Hub Transport roles which are part of unified mailbox role, whereas 2013 needs this in CAS and mailbox roles