### PR TITLE
Update requirements-applications.md

### DIFF
--- a/Azure-RMSDocs/requirements-applications.md
+++ b/Azure-RMSDocs/requirements-applications.md
@@ -50,7 +50,7 @@ These applications and solutions are known as "RMS-enlighted", and have Rights M
 |---------|---------|
 |**Word, Excel, PowerPoint**    | - [Microsoft 365 apps](#microsoft-365-app-support) <br />- Office 2010 <br />- Office 2013<br />- Office 2016 <br />- Office 2019 <br />- [Office for the web (viewing protected documents)](#viewing-protected-documents-in-office-for-the-web)<br />- [Web browser](#web-browser-support)        |
 |[**Email**](#viewing-protected-content-in-email-clients)      |   - Outlook 2010<br />- Outlook 2013<br />- Outlook 2016 <br />- Outlook 2019 <br />- Outlook from Microsoft 365 Apps for Enterprise<br />- [Web browser](#web-browser-support)<br />- [Windows Mail](#email-clients-using-exchange-activesync-irm)|
-|[**Other file types**](#supported-text-and-image-file-types)    |  - Visio from Microsoft 365 apps, Office 2019, and Office 2016: **.vsdm**, **.vsdx**, **.vssm**, **.vstm**, **.vssx**, **.vstx** <br />- Azure Information Protection client for Windows: Text, images, **pfile** <br />- [SealPath RMS plugin for AutoCAD](https://www.sealpath.com/rmscad/): **.dwg**       |
+|[**Other file types**](#supported-text-and-image-file-types)    |  - Visio from Microsoft 365 apps, Office 2019, and Office 2016: **.vsdm**, **.vsdx**, **.vssm**, **.vstm**, **.vssx**, **.vstx** <br />- Azure Information Protection client for Windows: Text, images, **pfile** <br />- [SealPath RMS plugin for AutoCAD](https://www.sealpath.com/rmscad/): **.dwg**       | [HALOCAD plugin for AutoCAD] (https://secude.com/halocad/): **.dwg**
 | | |
 
 ## macOS RMS-enlightened applications


### PR DESCRIPTION
Hi,

I represent SECUDE. Our solution HALOCAD extends Azure Information Protection (AIP) to protect the following native CAD files.

HALOCAD plugin for AutoCAD: .dwg, .dxf
HALOCAD plugin for Autodesk Inventor: .ipt, .iam, .idw, .ipn
HALOCAD plugin for PTC Creo: asm, prt, mfg, drw, frm, lay, s2d
HALOCAD plugin for Siemens NX: prt, jt

Check out:
https://secude.com/halocad/
https://azuremarketplace.microsoft.com/en-us/marketplace/apps/secudeinternationalag1579872706724.secude_halocad?tab=Overview

Regards,
Madhan
