### PR TITLE
Remove the HTTPS from the AD FS authorization rule

### DIFF
--- a/Azure-RMSDocs/active-directory-rights-manage-mobile-device.md
+++ b/Azure-RMSDocs/active-directory-rights-manage-mobile-device.md
@@ -120,7 +120,7 @@ c:[Type == "http://schemas.xmlsoap.org/claims/ProxyAddresses"]
 # Allow All users
 $AuthorizationRules = @"
 @RuleTemplate = "AllowAllAuthzRule"
- => issue(Type = "https://schemas.microsoft.com/authorization/claims/permit",
+ => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit",
 Value = "true");
 "@
 


### PR DESCRIPTION
The HTTPS in the authorization rule will cause AD FS to fail in the authorization stage. The right sintax is with HTTP:
"http://schemas.microsoft.com/authorization/claims/permit",