### PR TITLE
Update quick-app-initialization-cpp.md

### DIFF
--- a/mip/develop/quick-app-initialization-cpp.md
+++ b/mip/develop/quick-app-initialization-cpp.md
@@ -265,7 +265,7 @@ As mentioned, profile and engine objects are required for SDK clients using MIP 
                             "<application-version>"};
 
     // Create MipConfiguration object.
-    std::shared_ptr<mip::MipConfiguration> mipConfiguration = std::make_shared<mip::MipConfiguration>(mAppInfo,    
+    std::shared_ptr<mip::MipConfiguration> mipConfiguration = std::make_shared<mip::MipConfiguration>(appInfo,    
 				                                                                                               "mip_data", 
                                                                                         			         mip::LogLevel::Trace, 
                                                                                                        false);
@@ -281,7 +281,6 @@ As mentioned, profile and engine objects are required for SDK clients using MIP 
     FileProfile::Settings profileSettings(
                                   mMipContext,
                                   mip::CacheStorageType::OnDisk,
-                                  authDelegateImpl,
                                   consentDelegateImpl,
                                   profileObserver);
 
@@ -305,11 +304,12 @@ As mentioned, profile and engine objects are required for SDK clients using MIP 
     // Construct/initialize engine object
     FileEngine::Settings engineSettings(
                                     mip::Identity("<engine-account>"), // Engine identity (account used for authentication)
-                                    "<engine-state>",                  // User-defined engine state
+                                    authDelegateImpl,		       // Token acquisition implementation
+				    "<engine-state>",                  // User-defined engine state
                                     "en-US");                          // Locale (default = en-US)
                                     
     // Set the engineId for caching. 
-    engineSettings.setEngineId("<engine-account>");
+    engineSettings.SetEngineId("<engine-account>");
     // Set up promise/future connection for async engine operations; add engine to profile asynchronously
     auto enginePromise = make_shared<promise<shared_ptr<FileEngine>>>();
     auto engineFuture = enginePromise->get_future();
@@ -332,8 +332,8 @@ As mentioned, profile and engine objects are required for SDK clients using MIP 
     // handler = nullptr; // This will be used in later quick starts.
     engine = nullptr;
     profile = nullptr;   
-    mipContext.Shutdown();
-    mipContext = nullptr;
+    mMipContext->ShutDown();
+    mMipContext = nullptr;
 
     return 0;
     }


### PR DESCRIPTION
I was able to get the the [sensitivity labeling quickstart](https://docs.microsoft.com/en-us/information-protection/develop/quick-file-list-labels-cpp) up and running, but this required making a few changes to the boilerplate code in this section. Though I could be wrong, I believe the code actually won't compile as it's presented.

The changes I had to make:

* Changed `mAppInfo` reference to `appInfo`
* Removed `authDelegateImpl` from the `profileSettings` constructor
* Added `authDelegateImpl` to the `engineSettings` constructor
* Changed `setEngineId` to `SetEngineId`
* Changed `mipContext.Shutdown();` to `mMipContext->ShutDown();`
* Changed `mipContext = nullptr;` to `mMipContext = nullptr;`

Of course, feel free to let me know if the changes I'm proposing are symptomatic of a mistake on my end.